### PR TITLE
Added `#include <iterator> to `testing/CatchTests/RiemannRuleTest.cpp`

### DIFF
--- a/testing/CatchTests/RiemannRuleTests.cpp
+++ b/testing/CatchTests/RiemannRuleTests.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <cmath>
 #include <iostream>
+#include <iterator>
 #include <numeric>
 
 #include <catch2/benchmark/catch_benchmark.hpp>


### PR DESCRIPTION
`testing/CatchTests/RiemannRuleTest.cpp` is failing to compile with GCC13 (at least) because it is missing `#include <iterator>`.

This PR adds that include.

This addresses https://github.com/CD3/libIntegrate/issues/7.